### PR TITLE
allow create dataset from preexisting folder

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,10 +3,10 @@ from werkzeug.contrib.fixers import ProxyFix
 from flask_cors import CORS
 from watchdog.observers import Observer
 
-from .image_folder import ImageFolderHandler, load_images
+from .image_folder import ImageFolderHandler
 from .api import blueprint as api
 from .config import Config
-from .models import db
+from .models import db, ImageModel
 
 import threading
 import requests
@@ -53,7 +53,7 @@ app = create_app()
 db.init_app(app)
 
 if Config.LOAD_IMAGES_ON_START:
-    load_images(Config.DATASET_DIRECTORY)
+    ImageModel.load_images(Config.DATASET_DIRECTORY)
 
 
 @app.route('/', defaults={'path': ''})

--- a/app/image_folder.py
+++ b/app/image_folder.py
@@ -2,25 +2,6 @@ from watchdog.events import FileSystemEventHandler
 
 from .models import ImageModel
 
-import os
-
-
-PATTERN = (".gif", ".png", ".jpg", ".jpeg", ".bmp")
-
-
-def load_images(directory):
-    print("Checking all images in dataset directory (may take a few minutes)")
-    for root, dirs, files in os.walk(directory):
-        for file in files:
-            path = os.path.join(root, file)
-
-            if path.endswith(PATTERN):
-                db_image = ImageModel.objects(path=path).first()
-
-                if db_image is None:
-                    print("New file found: {}".format(path))
-                    ImageModel.create_from_path(path).save()
-
 
 class ImageFolderHandler(FileSystemEventHandler):
 


### PR DESCRIPTION
This change supports a special use-case: **Create a dataset from a folder which already contains images.** In my case, I'm volume mounting the `/datasets` folder from an existing folder on my host which already contains a bunch of datasets.

In order to accomplish this, I had to:
- load_images when the dataset folder already exists
- pass a dataset id to the load_images method, because the dataset does not yet exist in the db

Note: even with `config.LOAD_IMAGES_ON_START = True`, the images will be detected and added to the database, but without any dataset ids, and thus, they never show up in the UI.