### PR TITLE
ignore segments with only 2 points, as they are misinterpreted as bbox

### DIFF
--- a/app/util/coco_util.py
+++ b/app/util/coco_util.py
@@ -50,6 +50,12 @@ def paperjs_to_coco(image_width, image_height, paperjs):
         if sum(segments_to_add) == 0:
             continue
 
+        if len(segments_to_add) == 4:
+            # len 4 means this is a line with no width; it contributes
+            # no area to the mask, and if we include it, coco will treat
+            # it instead as a bbox (and throw an error)
+            continue
+
         num_widths = segments_to_add.count(image_width)
         num_heights = segments_to_add.count(image_height)
         if num_widths + num_heights == len(segments_to_add):


### PR DESCRIPTION
Since a segment with only 2 points is just a line, it can be safely ignored when considering area of the polygon. 

It could potentially extend the bounding box of a polygon--even though it contributes nothing to the area, but in my case, such lines were accidental artifacts of drawing a polygon and/or modifying/erasing part of a polygon.

I don't know of existing meaningful annotation types that include a polygon with area **and** a separate line--but if this type of annotation is to be supported, perhaps a different fix is required...