### PR TITLE
[WIP] Autoexport coco

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,6 +9,7 @@ from .config import Config
 from .models import *
 from .authentication import login_manager
 from .util import query_util, color_util
+from .util.autoexporter import Autoexporter
 
 import threading
 import requests
@@ -62,6 +63,12 @@ if Config.INITIALIZE_FROM_FILE:
 
 if Config.LOAD_IMAGES_ON_START:
     ImageModel.load_images(Config.DATASET_DIRECTORY)
+
+if Config.AUTOEXPORTER_ENABLED:
+    Autoexporter.start(
+        verbose=Config.AUTOEXPORTER_VERBOSE,
+        extension=Config.AUTOEXPORTER_EXTENSION,
+        logger=app.logger)
 
 
 @app.route('/', defaults={'path': ''})

--- a/app/api/annotator.py
+++ b/app/api/annotator.py
@@ -5,7 +5,7 @@ from flask import request
 from ..util import query_util
 from ..util import coco_util
 from ..models import *
-
+from ..util.autoexporter import Autoexporter
 
 api = Namespace('annotator', description='Annotator related operations')
 
@@ -94,6 +94,9 @@ class AnnotatorData(Resource):
             set__annotated=annotated,
             set__category_ids=image.get('category_ids', [])
         )
+
+        if Autoexporter.enabled:
+            Autoexporter.submit(image_model)
 
         return data
 

--- a/app/config.py
+++ b/app/config.py
@@ -21,6 +21,11 @@ class Config:
     INITIALIZE_FROM_FILE = os.getenv("INITIALIZE_FROM_FILE")
     LOAD_IMAGES_ON_START = os.getenv("LOAD_IMAGES_ON_START", False)
 
+    # Autoexporter Options
+    AUTOEXPORTER_ENABLED = os.getenv("AUTOEXPORTER_ENABLED", False)
+    AUTOEXPORTER_VERBOSE = os.getenv("AUTOEXPORTER_VERBOSE", False)
+    AUTOEXPORTER_EXTENSION = os.getenv("AUTOEXPORTER_EXTENSION", ".coco.json")
+
     # User Options
     LOGIN_DISABLED = os.getenv('LOGIN_DISABLED', False)
     ALLOW_REGISTRATION = True

--- a/app/util/autoexporter.py
+++ b/app/util/autoexporter.py
@@ -70,5 +70,5 @@ class Autoexporter:
             cls.log(f"Processing image {image_model.file_name}...")
 
         coco_json = get_image_coco(image_model)
-        coco_path = os.path.splitext(image_model.image_path)[0] + '.coco.json'
+        coco_path = os.path.splitext(image_model.path)[0] + '.coco.json'
         json.dump(coco_json, open(coco_path, 'w'))

--- a/app/util/autoexporter.py
+++ b/app/util/autoexporter.py
@@ -10,6 +10,7 @@ class Autoexporter:
     queue = None
     enabled = False
     verbose = False
+    extension = None
 
     @classmethod
     def log(cls, msg):
@@ -28,6 +29,7 @@ class Autoexporter:
             cls.executor.shutdown()
             del cls.executor
         cls.verbose = verbose
+        cls.extension = extension
         cls.executor = ExceptionLoggingThreadPoolExecutor(
             thread_name_prefix=cls.__name__,
             max_workers=max_workers,
@@ -52,5 +54,5 @@ class Autoexporter:
             cls.log(f"Processing image {image_model.file_name}...")
 
         coco_json = get_image_coco(image_model)
-        coco_path = os.path.splitext(image_model.path)[0] + '.coco.json'
+        coco_path = os.path.splitext(image_model.path)[0] + cls.extension
         json.dump(coco_json, open(coco_path, 'w'))

--- a/app/util/autoexporter.py
+++ b/app/util/autoexporter.py
@@ -1,0 +1,74 @@
+import queue
+import os
+import json
+from ..models import ImageModel
+from ..util.coco_util import get_image_coco
+from ..util.concurrency_util import ExceptionLoggingThreadPoolExecutor
+
+
+class Autoexporter:
+    executor = None
+    queue = None
+    enabled = False
+    verbose = False
+
+    @classmethod
+    def log(cls, msg):
+        print(f"[{cls.__name__}] {msg}", flush=True)
+
+    @classmethod
+    def submit(cls, image_model):
+        """
+        Submit an image for export
+        """
+        if cls.queue is not None:
+            cls.queue.put(image_model)
+
+    @classmethod
+    def start(cls, max_workers=1, max_queue_size=32,
+              verbose=False, logger=None, extension=".coco.json"):
+        """
+        Start the autoexporter background progresss.
+
+        @max_workers: max workers alloted to the thread pool executor
+        @max_queue_size: max size of the queue for annotations to be processed
+        """
+        if cls.executor is not None:
+            cls.executor.shutdown()
+            del cls.executor
+            del cls.queue
+        cls.queue = queue.Queue(maxsize=max_queue_size)
+        cls.verbose = verbose
+        cls.executor = ExceptionLoggingThreadPoolExecutor(
+            thread_name_prefix=cls.__name__,
+            max_workers=max_workers,
+            logger=logger)
+        cls.executor.submit(cls.do_export_images)
+        cls.enabled = True
+
+    @classmethod
+    def do_export_images(cls):
+        """
+        Performs automatic propagation of annotations by comparing
+        newly added/updated annotations: whenever
+        the annotation's patch is sufficiently close to the
+        corresponding patch on another image in the dataset, the
+        annotation is copied to this other image
+        """
+        while True:
+            image_model = cls.queue.get()
+            if image_model is not None:
+                cls.export_image(image_model)
+
+    @classmethod
+    def export_image(cls, image_model):
+        """
+        Exports the specified image to coco.json file, named after
+        the image and places it in the same folder as the image path.
+        """
+        if cls.verbose:
+            cls.log(f"Processing image {image_model.file_name}...")
+
+        coco_json = get_image_coco(image_model)
+        coco_path = os.path.splitext(image_model.image_path)[0] + '.coco.json'
+        json.dump(coco_json, open(coco_path, 'w'))

--- a/app/util/concurrency_util.py
+++ b/app/util/concurrency_util.py
@@ -1,0 +1,25 @@
+from concurrent.futures import ThreadPoolExecutor
+import traceback
+
+class ExceptionLoggingThreadPoolExecutor(ThreadPoolExecutor):
+    def __init__(self, max_workers, thread_name_prefix=None, logger=None):
+        super().__init__(max_workers=max_workers,
+                         thread_name_prefix=thread_name_prefix)
+        self.logger = logger
+
+    def submit(self, fn, *args, **kwargs):
+        return super().submit(self.exception_logger, fn, *args, **kwargs)
+
+    def exception_logger(self, fn, *args, **kwargs): 
+        """
+        Waits for future's result and logs any thrown exception
+        """
+        try:
+            fn(*args, **kwargs)
+        except Exception:
+            msg = (f"[{self._thread_name_prefix}]"
+                   f"{traceback.format_exc()}")
+            if self.logger:
+                self.logger.error(msg)
+            else:
+                print(msg, flush=True)


### PR DESCRIPTION
This adds the capability to auto-export a coco json file to the same folder as the image `path`, with default extension (configurable) of `.coco.json`, whenever the image's annotations are updated.

For example, when `/datasets/animals/aligator.jpg` is annotated, and you save (or cause the image to be saved by moving to the next image, etc.), the file `/datasets/animals/aligator.coco.json` is created/udpated in the background. 