### PR TITLE
Update category names

### DIFF
--- a/client/src/components/cards/CategoryCard.vue
+++ b/client/src/components/cards/CategoryCard.vue
@@ -42,6 +42,13 @@
           <!--<a class="dropdown-item" @click="onDownloadClick"
             >Download COCO & Images</a
           >-->
+          <button
+            class="dropdown-item"
+            data-toggle="modal"
+            :data-target="'#categoryEdit' + category.id"
+          >
+            Edit
+          </button>
         </div>
       </div>
 
@@ -52,14 +59,68 @@
         Created by {{ category.creator }}
       </div>
     </div>
+
+    <div class="modal fade" role="dialog" :id="'categoryEdit' + category.id">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Current Name: {{ category.name }}</h5>
+            <button
+              type="button"
+              class="close"
+              data-dismiss="modal"
+              aria-label="Close"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <form>
+              <div class="form-group">
+                <label>Edit name: </label>
+                <input type="text" 
+                v-bind:value="category.name"
+                v-on:input="updatedCategoryName = $event.target.value">
+              </div>
+            </form>
+          </div>
+          <div class="modal-footer">
+            <button
+              type="button"
+              class="btn btn-success"
+              @click="onUpdateClick"
+              data-dismiss="modal"
+            >
+              Update
+            </button>
+            <button
+              type="button"
+              class="btn btn-secondary"
+              data-dismiss="modal"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
   </div>
 </template>
 
 <script>
 import axios from "axios";
+import toastrs from "@/mixins/toastrs";
 
 export default {
   name: "CategoryCard",
+  mixins: [toastrs],
+  data () {
+    return {
+      updatedCategoryName: ''
+    }
+  },
   props: {
     category: {
       type: Object,
@@ -72,6 +133,27 @@ export default {
     onDownloadClick() {},
     onDeleteClick() {
       axios.delete("/api/category/" + this.category.id).then(() => {
+        this.$parent.updatePage();
+      });
+    },
+    onUpdateClick() {
+      axios
+      .put("/api/category/" + this.category.id, {
+        name: this.updatedCategoryName
+      })
+      .then(response => {
+        this.axiosReqestSuccess(
+          "Updating Category",
+          "Category name has been updated"
+        );
+        this.category.name = this.updatedCategoryName;
+        this.$parent.updatePage();
+      })
+      .catch(error => {
+        this.axiosReqestError(
+          "Updating Category",
+          error.response.data.message
+          );
         this.$parent.updatePage();
       });
     }

--- a/tests/api/test_category.py
+++ b/tests/api/test_category.py
@@ -103,6 +103,54 @@ class TestCategoryId:
         response = client.delete("/api/category/{}".format(category3_id))
         assert response.status_code == 200
 
+    @pytest.mark.run(after='test_post_categories')
+    def test_put_equal(self, client):
+        """ Test response when the name to update is the same as already stored """
+        data = {
+            "name": "test1"
+        }
+        response = client.put("/api/category/{}".format(category1_id), json=data)
+        assert response.status_code == 200
+
+    def test_put_invalid_id(self, client):
+        """ Test response when id does not exit """
+        response = client.put("/api/category/1000")
+        assert response.status_code == 400
+
+    def test_put_not_unique(self, client):
+        """ Test response when the name already exits """
+        data = {
+            "name": "test2"
+        }
+        response = client.put("/api/category/{}".format(category1_id), json=data)
+        assert response.status_code == 400
+
+    def test_put_empty(self, client):
+        """ Test response when category name is empty"""
+        data = {
+            "name": ""
+        }
+        response = client.put("/api/category/{}".format(category1_id), json=data)
+        assert response.status_code == 400
+
+    @pytest.mark.run(after='test_put_not_unique')
+    def test_put(self, client):
+        """ Test response when update is correct"""
+        data = {
+            "name": "test1_updated"
+        }
+        response = client.put("/api/category/{}".format(category1_id), json=data)
+        assert response.status_code == 200
+
+    @pytest.mark.run(after='test_put')
+    def test_put_reset(self, client):
+        """ Reset test after a correct update """
+        data = {
+            "name": "test1"
+        }
+        response = client.put("/api/category/{}".format(category1_id), json=data)
+        assert response.status_code == 200
+
 
 class TestCategoryData:
 


### PR DESCRIPTION
Enables users to rename categories. Equal category names are not allowed due to unique property on creator.
* Rename categories in dialog
* Process put request and response
* Check for equal names after renaming
* Test updates functions

Resolves #123