### PR TITLE
Bounding Box tool for rectangular segmentation. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@
   </a>
 </p>
 
-### Warning: If you plan to run this with an external access please make sure you using a firewall to pervernt access to the database!
-
 COCO Annotator is a web-based image annotation tool designed for versatility and efficiently label images to create training data for image localization and object detection. It provides many distinct features including the ability to label an image segment (or part of a segment), track object instances, labeling objects with disconnected visible parts, efficiently storing and export annotations in the well-known [COCO format](http://cocodataset.org/#format-data). The annotation process is delivered through an intuitive and customizable interface and provides many tools for creating accurate datasets.
 
 <p align="center"><img width="600" src="https://i.imgur.com/m4RmjCp.gif"></p>

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
   </a>
 </p>
 
+### Warning: If you plan to run this with an external access please make sure you using a firewall to pervernt access to the database!
+
 COCO Annotator is a web-based image annotation tool designed for versatility and efficiently label images to create training data for image localization and object detection. It provides many distinct features including the ability to label an image segment (or part of a segment), track object instances, labeling objects with disconnected visible parts, efficiently storing and export annotations in the well-known [COCO format](http://cocodataset.org/#format-data). The annotation process is delivered through an intuitive and customizable interface and provides many tools for creating accurate datasets.
 
 <p align="center"><img width="600" src="https://i.imgur.com/m4RmjCp.gif"></p>

--- a/backend/database/annotations.py
+++ b/backend/database/annotations.py
@@ -13,7 +13,7 @@ class AnnotationModel(DynamicDocument):
 
     COCO_PROPERTIES = ["id", "image_id", "category_id", "segmentation",
                        "iscrowd", "color", "area", "bbox", "metadata",
-                       "keypoints"]
+                       "keypoints", "isbbox"]
 
     id = SequenceField(primary_key=True)
     image_id = IntField(required=True)
@@ -24,6 +24,7 @@ class AnnotationModel(DynamicDocument):
     area = IntField(default=0)
     bbox = ListField(default=[0, 0, 0, 0])
     iscrowd = BooleanField(default=False)
+    isbbox = BooleanField(default=False)
 
     creator = StringField(required=True)
     width = IntField()

--- a/backend/database/images.py
+++ b/backend/database/images.py
@@ -143,7 +143,8 @@ class ImageModel(DynamicDocument):
         :param annotations: QuerySet of annotation models
         :return: number of annotations
         """
-        annotations = annotations.filter(width=self.width, height=self.height, area__gt=0)
+        annotations = annotations.filter(
+            width=self.width, height=self.height, area__gt=0).exclude('events')
 
         for annotation in annotations:
             clone = annotation.clone()

--- a/backend/webserver/api/annotations.py
+++ b/backend/webserver/api/annotations.py
@@ -14,6 +14,7 @@ create_annotation = reqparse.RequestParser()
 create_annotation.add_argument(
     'image_id', type=int, required=True, location='json')
 create_annotation.add_argument('category_id', type=int, location='json')
+create_annotation.add_argument('isbbox', type=bool, location='json')
 create_annotation.add_argument('metadata', type=dict, location='json')
 create_annotation.add_argument('segmentation', type=list, location='json')
 create_annotation.add_argument('keypoints', type=list, location='json')
@@ -35,6 +36,7 @@ class Annotation(Resource):
         args = create_annotation.parse_args()
         image_id = args.get('image_id')
         category_id = args.get('category_id')
+        isbbox = args.get('isbbox')
         metadata = args.get('metadata', {})
         segmentation = args.get('segmentation', [])
         keypoints = args.get('keypoints', [])
@@ -42,7 +44,9 @@ class Annotation(Resource):
         image = current_user.images.filter(id=image_id, deleted=False).first()
         if image is None:
             return {"message": "Invalid image id"}, 400
-
+        
+        logger.info(
+            f'{current_user.username} has created an annotation for image {image_id} with {isbbox}')
         logger.info(
             f'{current_user.username} has created an annotation for image {image_id}')
 
@@ -52,7 +56,8 @@ class Annotation(Resource):
                 category_id=category_id,
                 metadata=metadata,
                 segmentation=segmentation,
-                keypoints=keypoints
+                keypoints=keypoints,
+                isbbox=isbbox
             )
             annotation.save()
         except (ValueError, TypeError) as e:

--- a/backend/webserver/api/annotator.py
+++ b/backend/webserver/api/annotator.py
@@ -95,6 +95,7 @@ class AnnotatorData(Resource):
                 db_annotation.update(
                     add_to_set__events=sessions,
                     inc__milliseconds=total_time,
+                    set__isbbox=annotation.get('isbbox', False),
                     set__keypoints=annotation.get('keypoints', []),
                     set__metadata=annotation.get('metadata'),
                     set__color=annotation.get('color')
@@ -115,6 +116,7 @@ class AnnotatorData(Resource):
                     db_annotation.update(
                         set__segmentation=segmentation,
                         set__area=area,
+                        set__isbbox=annotation.get('isbbox', False),
                         set__bbox=bbox,
                         set__paper_object=paperjs_object,
                     )

--- a/client/src/components/annotator/Annotation.vue
+++ b/client/src/components/annotator/Annotation.vue
@@ -537,15 +537,14 @@ export default {
      */
     unite(compound, simplify = true, undoable = true, isBBox = false) {
       if (this.compoundPath == null) this.createCompoundPath();
-      this.compoundPath.data.isBBox = isBBox;
+
       let newCompound = this.compoundPath.unite(compound);
       newCompound.strokeColor = null;
       newCompound.strokeWidth = 0;
       newCompound.onDoubleClick = this.compoundPath.onDoubleClick;
       newCompound.onClick = this.compoundPath.onClick;
-      newCompound.data.isBBox = isBBox
-      console.log(newCompound);
-
+      this.annotation.isbbox = isBBox;
+      
       if (undoable) this.createUndoAction("Unite");
 
       this.compoundPath.remove();
@@ -591,6 +590,7 @@ export default {
       if (this.name.length > 0) metadata.name = this.name;
       let annotationData = {
         id: this.annotation.id,
+        isbbox: this.annotation.isbbox,
         color: this.color,
         metadata: metadata
       };

--- a/client/src/components/annotator/Annotation.vue
+++ b/client/src/components/annotator/Annotation.vue
@@ -288,7 +288,7 @@ export default {
         this.annotation.segmentation
       );
     },
-    createCompoundPath(json, segments, isBbox = false) {
+    createCompoundPath(json, segments) {
       json = json || null;
       segments = segments || null;
 
@@ -357,7 +357,6 @@ export default {
 
       this.compoundPath.data.annotationId = this.index;
       this.compoundPath.data.categoryId = this.categoryIndex;
-      this.compoundPath.data.isBbox = isBbox;
 
       this.compoundPath.fullySelected = this.isCurrent;
       this.compoundPath.opacity = this.opacity;
@@ -534,16 +533,18 @@ export default {
      * @param {paper.CompoundPath} compound compound to unite current annotation path with
      * @param {boolean} simplify simplify compound after unite
      * @param {undoable} undoable add an undo action.
-     * @param {isBbox} isBbox mark annotation as bbox.
+     * @param {isBBox} isBBox mark annotation as bbox.
      */
-    unite(compound, simplify = true, undoable = true, isBbox = false) {
-      if (this.compoundPath == null) this.createCompoundPath(undefined, undefined, isBbox);
-
+    unite(compound, simplify = true, undoable = true, isBBox = false) {
+      if (this.compoundPath == null) this.createCompoundPath();
+      this.compoundPath.data.isBBox = isBBox;
       let newCompound = this.compoundPath.unite(compound);
       newCompound.strokeColor = null;
       newCompound.strokeWidth = 0;
       newCompound.onDoubleClick = this.compoundPath.onDoubleClick;
       newCompound.onClick = this.compoundPath.onClick;
+      newCompound.data.isBBox = isBBox
+      console.log(newCompound);
 
       if (undoable) this.createUndoAction("Unite");
 
@@ -586,7 +587,6 @@ export default {
     },
     export() {
       if (this.compoundPath == null) this.createCompoundPath();
-
       let metadata = this.$refs.metadata.export();
       if (this.name.length > 0) metadata.name = this.name;
       let annotationData = {

--- a/client/src/components/annotator/Annotation.vue
+++ b/client/src/components/annotator/Annotation.vue
@@ -288,7 +288,7 @@ export default {
         this.annotation.segmentation
       );
     },
-    createCompoundPath(json, segments) {
+    createCompoundPath(json, segments, isBbox = false) {
       json = json || null;
       segments = segments || null;
 
@@ -357,6 +357,7 @@ export default {
 
       this.compoundPath.data.annotationId = this.index;
       this.compoundPath.data.categoryId = this.categoryIndex;
+      this.compoundPath.data.isBbox = isBbox;
 
       this.compoundPath.fullySelected = this.isCurrent;
       this.compoundPath.opacity = this.opacity;
@@ -532,10 +533,11 @@ export default {
      * Unites current annotation path with anyother path.
      * @param {paper.CompoundPath} compound compound to unite current annotation path with
      * @param {boolean} simplify simplify compound after unite
-     * @param {undoable} undoable add an undo action
+     * @param {undoable} undoable add an undo action.
+     * @param {isBbox} isBbox mark annotation as bbox.
      */
-    unite(compound, simplify = true, undoable = true) {
-      if (this.compoundPath == null) this.createCompoundPath();
+    unite(compound, simplify = true, undoable = true, isBbox = false) {
+      if (this.compoundPath == null) this.createCompoundPath(undefined, undefined, isBbox);
 
       let newCompound = this.compoundPath.unite(compound);
       newCompound.strokeColor = null;

--- a/client/src/components/annotator/Category.vue
+++ b/client/src/components/annotator/Category.vue
@@ -211,7 +211,6 @@ export default {
       Annotations.create({
         image_id: parent.image.id,
         category_id: this.category.id,
-        isbbox: localStorage.getItem("editorTool") == "BBox"
       }).then(response => {
         this.$socket.emit("annotation", {
           action: "create",

--- a/client/src/components/annotator/Category.vue
+++ b/client/src/components/annotator/Category.vue
@@ -208,10 +208,10 @@ export default {
     createAnnotation() {
       let parent = this.$parent;
       let annotationId = this.category.annotations.length;
-
       Annotations.create({
         image_id: parent.image.id,
-        category_id: this.category.id
+        category_id: this.category.id,
+        isbbox: localStorage.getItem("editorTool") == "BBox"
       }).then(response => {
         this.$socket.emit("annotation", {
           action: "create",

--- a/client/src/components/annotator/panels/BBoxPanel.vue
+++ b/client/src/components/annotator/panels/BBoxPanel.vue
@@ -1,7 +1,6 @@
 <template>
   <div v-show="bbox.isActive">
-    <PanelButton name="Delete BBox" @click="bbox.deletePolygon" />
-    <PanelToggle name="Guidance" v-model="bbox.polygon.guidance" />
+    <PanelButton name="Delete BBox" @click="bbox.deleteBbox" />
     <PanelToggle name="Auto Select Color" v-model="bbox.color.auto" />
     <PanelToggle
       v-show="bbox.color.auto"

--- a/client/src/components/annotator/panels/BBoxPanel.vue
+++ b/client/src/components/annotator/panels/BBoxPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <div v-show="bbox.isActive">
     <PanelButton name="Delete BBox" @click="bbox.deletePolygon" />
+    <PanelToggle name="Guidance" v-model="bbox.polygon.guidance" />
     <PanelToggle name="Auto Select Color" v-model="bbox.color.auto" />
     <PanelToggle
       v-show="bbox.color.auto"

--- a/client/src/components/annotator/panels/BBoxPanel.vue
+++ b/client/src/components/annotator/panels/BBoxPanel.vue
@@ -1,0 +1,33 @@
+<template>
+  <div v-show="bbox.isActive">
+    <PanelButton name="Delete BBox" @click="bbox.deletePolygon" />
+    <PanelToggle name="Auto Select Color" v-model="bbox.color.auto" />
+    <PanelToggle
+      v-show="bbox.color.auto"
+      name="Only Black or White"
+      v-model="bbox.color.blackOrWhite"
+    />
+    <PanelInputString
+      name="Stroke Color"
+      v-model="bbox.polygon.pathOptions.strokeColor"
+    />
+  </div>
+</template>
+
+<script>
+import PanelButton from "@/components/PanelButton";
+import PanelToggle from "@/components/PanelToggle";
+import PanelInputString from "@/components/PanelInputString";
+import PanelInputNumber from "@/components/PanelInputNumber";
+
+export default {
+  name: "BBoxPanel",
+  components: { PanelButton, PanelToggle, PanelInputString, PanelInputNumber },
+  props: {
+    bbox: {
+      type: Object,
+      required: true
+    }
+  }
+};
+</script>

--- a/client/src/components/annotator/tools/BBoxTool.vue
+++ b/client/src/components/annotator/tools/BBoxTool.vue
@@ -29,6 +29,7 @@ export default {
       bbox: null,
       polygon: {
         path: null,
+        guidance: true,
         pathOptions: {
           strokeColor: "black",
           strokeWidth: 1

--- a/client/src/components/annotator/tools/BBoxTool.vue
+++ b/client/src/components/annotator/tools/BBoxTool.vue
@@ -28,11 +28,8 @@ export default {
       cursor: "copy",
       bbox: null,
       polygon: {
-        completeDistance: 5,
-        minDistance: 2,
         path: null,
         guidance: false,
-        simplify: 1,
         pathOptions: {
           strokeColor: "black",
           strokeWidth: 1
@@ -72,18 +69,6 @@ export default {
       this.color.blackOrWhite = pref.blackOrWhite || this.color.blackOrWhite;
       this.color.auto = pref.auto || this.color.auto;
       this.color.radius = pref.radius || this.color.radius;
-    },
-    /**
-     * Creates a new selection polygon path
-     */
-    createPolygon() {
-      if (this.color.auto) {
-        this.color.circle = new paper.Path.Circle(
-          new paper.Point(0, 0),
-          this.color.radius
-        );
-      }
-      this.polygon.path = new paper.Path(this.polygon.pathOptions);
     },
     createBBox(event) {
       this.polygon.path = new paper.Path(this.polygon.pathOptions);
@@ -186,8 +171,10 @@ export default {
       this.polygon.path.fillColor = "black";
       this.polygon.path.closePath();
 
-      this.$parent.uniteCurrentAnnotation(this.polygon.path, true, true, true);
+      this.$parent.uniteCurrentAnnotation(this.polygon.path);
 
+      this.$parent.currentCategory.createAnnotation();
+      
       this.polygon.path.remove();
       this.polygon.path = null;
       if (this.color.circle) {
@@ -223,9 +210,6 @@ export default {
       if (this.polygon.path != null)
         this.polygon.path.strokeWidth = newScale * this.scaleFactor;
     },
-    "polygon.minDistance"(newDistance) {
-      this.tool.minDistance = newDistance;
-    },
     "polygon.pathOptions.strokeColor"(newColor) {
       if (this.polygon.path == null) return;
 
@@ -245,8 +229,6 @@ export default {
     }
   },
   created() {},
-  mounted() {
-    this.tool.minDistance = this.minDistance;
-  }
+  mounted() {}
 };
 </script>

--- a/client/src/components/annotator/tools/BBoxTool.vue
+++ b/client/src/components/annotator/tools/BBoxTool.vue
@@ -186,7 +186,7 @@ export default {
       this.polygon.path.fillColor = "black";
       this.polygon.path.closePath();
 
-      this.$parent.uniteCurrentAnnotation(this.polygon.path);
+      this.$parent.uniteCurrentAnnotation(this.polygon.path, true, true, true);
 
       this.polygon.path.remove();
       this.polygon.path = null;

--- a/client/src/components/annotator/tools/BBoxTool.vue
+++ b/client/src/components/annotator/tools/BBoxTool.vue
@@ -83,6 +83,25 @@ export default {
       }
       this.polygon.path = new paper.Path(this.polygon.pathOptions);
     },
+    createBBox(event) {
+      console.log(event)
+      if (this.color.auto) {
+        this.color.circle = new paper.Path.Rectangle({
+          x: 50,
+          y: 50,
+          width: 100, 
+          height:100
+        });
+      }
+      this.polygon.path = new paper.Path(this.polygon.pathOptions);
+      this.polygon.path.add({x:300, y:50});
+      this.polygon.path.add({x:300, y:300});
+      this.polygon.path.add({x:50, y:300});
+      this.polygon.path.add({x:50, y:50});
+      this.polygon.path.add({x:50, y:50});
+
+      this.complete();
+    },
     /**
      * Frees current polygon
      */
@@ -122,17 +141,18 @@ export default {
       let wasNull = false;
       if (this.polygon.path == null) {
         wasNull = true;
-        this.createPolygon();
+        this.createBBox(event);
       }
       console.log(`mouse point ${event.point}`)
       this.actionPoints = 1;
-      this.polygon.path.add(event.point);
+      // this.polygon.path.add(event.point);
 
-      if (this.autoComplete(3)) return;
+      // if (this.autoComplete(3)) return;
 
-      if (this.polygon.guidance && wasNull) this.polygon.path.add(event.point);
+      // if (this.polygon.guidance && wasNull) this.polygon.path.add(event.point);
     },
-    onMouseUp() {
+    onMouseUp(event) {
+      // this.createBBox(event);
       if (this.polygon.path == null) return;
       let action = new UndoAction({
         name: this.name,
@@ -255,9 +275,9 @@ export default {
     },
     "color.auto"(value) {
       if (value && this.polygon.path) {
-        this.color.circle = new paper.Path.Circle(
+        this.color.circle = new paper.Path.Rectangle(
           new paper.Point(0, 0),
-          this.color.radius
+          new paper.Size(10, 10)
         );
       }
       if (!value && this.color.circle) {

--- a/client/src/components/annotator/tools/BBoxTool.vue
+++ b/client/src/components/annotator/tools/BBoxTool.vue
@@ -223,16 +223,6 @@ export default {
       if (this.polygon.path != null)
         this.polygon.path.strokeWidth = newScale * this.scaleFactor;
     },
-    // /**
-    //  * Remove last point (point were mouse was) if enable guidane
-    //  */
-    // "polygon.guidance"(guidance) {
-    //   if (this.polygon.path == null) return;
-
-    //   if (!guidance && this.polygon.path.length > 1) {
-    //     this.removeLastPoint();
-    //   }
-    // },
     "polygon.minDistance"(newDistance) {
       this.tool.minDistance = newDistance;
     },

--- a/client/src/components/annotator/tools/BBoxTool.vue
+++ b/client/src/components/annotator/tools/BBoxTool.vue
@@ -4,6 +4,7 @@ import tool from "@/mixins/toolBar/tool";
 import UndoAction from "@/undo";
 
 import { invertColor } from "@/libs/colors";
+import { BBox } from "@/libs/bbox";
 import { mapMutations } from "vuex";
 
 export default {
@@ -25,11 +26,12 @@ export default {
       name: "BBox",
       scaleFactor: 3,
       cursor: "copy",
+      bbox: null,
       polygon: {
         completeDistance: 5,
         minDistance: 2,
         path: null,
-        guidance: true,
+        guidance: false,
         simplify: 1,
         pathOptions: {
           strokeColor: "black",
@@ -84,23 +86,17 @@ export default {
       this.polygon.path = new paper.Path(this.polygon.pathOptions);
     },
     createBBox(event) {
-      console.log(event)
-      if (this.color.auto) {
-        this.color.circle = new paper.Path.Rectangle({
-          x: 50,
-          y: 50,
-          width: 100, 
-          height:100
-        });
-      }
       this.polygon.path = new paper.Path(this.polygon.pathOptions);
-      this.polygon.path.add({x:300, y:50});
-      this.polygon.path.add({x:300, y:300});
-      this.polygon.path.add({x:50, y:300});
-      this.polygon.path.add({x:50, y:50});
-      this.polygon.path.add({x:50, y:50});
+      this.bbox = new BBox(event.point);
+      this.bbox.getPoints().forEach((point) => this.polygon.path.add(point))
+      
+    },
 
-      this.complete();
+    modifyBBox(event) {
+      this.polygon.path = new paper.Path(this.polygon.pathOptions);
+      this.bbox.modifyPoint(event.point)
+      this.bbox.getPoints().forEach((point) => this.polygon.path.add(point));
+      
     },
     /**
      * Frees current polygon
@@ -135,21 +131,17 @@ export default {
       this.actionPoints++;
       this.autoStrokeColor(event.point);
       this.polygon.path.add(event.point);
-      this.autoComplete(30);
     },
     onMouseDown(event) {
-      let wasNull = false;
-      if (this.polygon.path == null) {
-        wasNull = true;
+      if(this.polygon.path == null) {
         this.createBBox(event);
+        return;
       }
-      console.log(`mouse point ${event.point}`)
-      this.actionPoints = 1;
-      // this.polygon.path.add(event.point);
+      this.removeLastBBox();
+      this.modifyBBox(event);
+      
+      if (this.completeBBox()) return;
 
-      // if (this.autoComplete(3)) return;
-
-      // if (this.polygon.guidance && wasNull) this.polygon.path.add(event.point);
     },
     onMouseUp(event) {
       // this.createBBox(event);
@@ -171,8 +163,8 @@ export default {
       this.autoStrokeColor(event.point);
 
       if (!this.polygon.guidance) return;
-      this.removeLastPoint();
-      this.polygon.path.add(event.point);
+      this.removeLastBBox();
+      this.modifyBBox(event);
     },
     /**
      * Undo points
@@ -183,39 +175,20 @@ export default {
       let points = args.points;
       let length = this.polygon.path.segments.length;
 
-      if (this.polygon.guidance) {
+      if  (this.polygon.guidance) {
         length -= 1;
       }
 
       this.polygon.path.removeSegments(length - points, length);
     },
     /**
-     * Completes polygon if point being added is close to first point
-     * @returns {boolean} sucessfully closes object
-     */
-    autoComplete(minCompleteLength) {
-      if (this.polygon.path == null) return false;
-      if (this.polygon.path.segments.length < minCompleteLength) return false;
-
-      let last = this.polygon.path.lastSegment.point;
-      let first = this.polygon.path.firstSegment.point;
-
-      let completeDistance = this.polygon.completeDistance;
-      if (last.isClose(first, completeDistance)) {
-        return this.complete();
-      }
-
-      return false;
-    },
-    /**
      * Closes current polygon and unites it with current annotaiton.
      * @returns {boolean} sucessfully closes object
      */
-    complete() {
+    completeBBox() {
       if (this.polygon.path == null) return false;
 
-      this.removeLastPoint();
-
+      
       this.polygon.path.fillColor = "black";
       this.polygon.path.closePath();
 
@@ -229,10 +202,11 @@ export default {
       }
 
       this.removeUndos(this.actionTypes.ADD_POINTS);
+      
       return true;
     },
-    removeLastPoint() {
-      this.polygon.path.removeSegment(this.polygon.path.segments.length - 1);
+    removeLastBBox() {
+      this.polygon.path.removeSegments();
     }
   },
   computed: {
@@ -255,16 +229,16 @@ export default {
       if (this.polygon.path != null)
         this.polygon.path.strokeWidth = newScale * this.scaleFactor;
     },
-    /**
-     * Remove last point (point were mouse was) if enable guidane
-     */
-    "polygon.guidance"(guidance) {
-      if (this.polygon.path == null) return;
+    // /**
+    //  * Remove last point (point were mouse was) if enable guidane
+    //  */
+    // "polygon.guidance"(guidance) {
+    //   if (this.polygon.path == null) return;
 
-      if (!guidance && this.polygon.path.length > 1) {
-        this.removeLastPoint();
-      }
-    },
+    //   if (!guidance && this.polygon.path.length > 1) {
+    //     this.removeLastPoint();
+    //   }
+    // },
     "polygon.minDistance"(newDistance) {
       this.tool.minDistance = newDistance;
     },

--- a/client/src/components/annotator/tools/BBoxTool.vue
+++ b/client/src/components/annotator/tools/BBoxTool.vue
@@ -126,12 +126,6 @@ export default {
         );
       }
     },
-    onMouseDrag(event) {
-      if (this.polygon.path == null) return;
-      this.actionPoints++;
-      this.autoStrokeColor(event.point);
-      this.polygon.path.add(event.point);
-    },
     onMouseDown(event) {
       if(this.polygon.path == null) {
         this.createBBox(event);

--- a/client/src/components/annotator/tools/BBoxTool.vue
+++ b/client/src/components/annotator/tools/BBoxTool.vue
@@ -1,0 +1,274 @@
+<script>
+import paper from "paper";
+import tool from "@/mixins/toolBar/tool";
+import UndoAction from "@/undo";
+
+import { invertColor } from "@/libs/colors";
+import { mapMutations } from "vuex";
+
+export default {
+  name: "BBoxTool",
+  mixins: [tool],
+  props: {
+    scale: {
+      type: Number,
+      default: 1
+    },
+    settings: {
+      type: [Object, null],
+      default: null
+    }
+  },
+  data() {
+    return {
+      icon: "fa-object-group",
+      name: "BBox",
+      scaleFactor: 3,
+      cursor: "copy",
+      polygon: {
+        completeDistance: 5,
+        minDistance: 2,
+        path: null,
+        guidance: true,
+        simplify: 1,
+        pathOptions: {
+          strokeColor: "black",
+          strokeWidth: 1
+        }
+      },
+      color: {
+        blackOrWhite: true,
+        auto: true,
+        radius: 10,
+        circle: null
+      },
+      actionTypes: Object.freeze({
+        ADD_POINTS: "Added Points",
+        CLOSED_POLYGON: "Closed Polygon",
+        DELETE_POLYGON: "Delete Polygon"
+      }),
+      actionPoints: 0
+    };
+  },
+  methods: {
+    ...mapMutations(["addUndo", "removeUndos"]),
+    export() {
+      return {
+        guidance: this.polygon.guidance,
+        completeDistance: this.polygon.completeDistance,
+        minDistance: this.polygon.minDistance,
+        blackOrWhite: this.color.blackOrWhite,
+        auto: this.color.auto,
+        radius: this.color.radius
+      };
+    },
+    setPreferences(pref) {
+      this.polygon.guidance = pref.guidance || this.polygon.guidance;
+      this.polygon.completeDistance =
+        pref.completeDistance || this.polygon.completeDistance;
+      this.polygon.minDistance = pref.minDistance || this.polygon.minDistance;
+      this.color.blackOrWhite = pref.blackOrWhite || this.color.blackOrWhite;
+      this.color.auto = pref.auto || this.color.auto;
+      this.color.radius = pref.radius || this.color.radius;
+    },
+    /**
+     * Creates a new selection polygon path
+     */
+    createPolygon() {
+      if (this.color.auto) {
+        this.color.circle = new paper.Path.Circle(
+          new paper.Point(0, 0),
+          this.color.radius
+        );
+      }
+      this.polygon.path = new paper.Path(this.polygon.pathOptions);
+    },
+    /**
+     * Frees current polygon
+     */
+    deletePolygon() {
+      if (this.polygon.path == null) return;
+
+      this.polygon.path.remove();
+      this.polygon.path = null;
+
+      if (this.color.circle == null) return;
+      this.color.circle.remove();
+      this.color.circle = null;
+    },
+    autoStrokeColor(point) {
+      if (this.color.circle == null) return;
+      if (this.polygon.path == null) return;
+      if (!this.color.auto) return;
+
+      this.color.circle.position = point;
+      let raster = this.$parent.image.raster;
+      let color = raster.getAverageColor(this.color.circle);
+      if (color) {
+        this.polygon.pathOptions.strokeColor = invertColor(
+          color.toCSS(true),
+          this.color.blackOrWhite
+        );
+      }
+    },
+    onMouseDrag(event) {
+      if (this.polygon.path == null) return;
+      this.actionPoints++;
+      this.autoStrokeColor(event.point);
+      this.polygon.path.add(event.point);
+      this.autoComplete(30);
+    },
+    onMouseDown(event) {
+      let wasNull = false;
+      if (this.polygon.path == null) {
+        wasNull = true;
+        this.createPolygon();
+      }
+      console.log(`mouse point ${event.point}`)
+      this.actionPoints = 1;
+      this.polygon.path.add(event.point);
+
+      if (this.autoComplete(3)) return;
+
+      if (this.polygon.guidance && wasNull) this.polygon.path.add(event.point);
+    },
+    onMouseUp() {
+      if (this.polygon.path == null) return;
+      let action = new UndoAction({
+        name: this.name,
+        action: this.actionTypes.ADD_POINTS,
+        func: this.undoPoints,
+        args: {
+          points: this.actionPoints
+        }
+      });
+
+      this.addUndo(action);
+    },
+    onMouseMove(event) {
+      if (this.polygon.path == null) return;
+      if (this.polygon.path.segments.length === 0) return;
+      this.autoStrokeColor(event.point);
+
+      if (!this.polygon.guidance) return;
+      this.removeLastPoint();
+      this.polygon.path.add(event.point);
+    },
+    /**
+     * Undo points
+     */
+    undoPoints(args) {
+      if (this.polygon.path == null) return;
+
+      let points = args.points;
+      let length = this.polygon.path.segments.length;
+
+      if (this.polygon.guidance) {
+        length -= 1;
+      }
+
+      this.polygon.path.removeSegments(length - points, length);
+    },
+    /**
+     * Completes polygon if point being added is close to first point
+     * @returns {boolean} sucessfully closes object
+     */
+    autoComplete(minCompleteLength) {
+      if (this.polygon.path == null) return false;
+      if (this.polygon.path.segments.length < minCompleteLength) return false;
+
+      let last = this.polygon.path.lastSegment.point;
+      let first = this.polygon.path.firstSegment.point;
+
+      let completeDistance = this.polygon.completeDistance;
+      if (last.isClose(first, completeDistance)) {
+        return this.complete();
+      }
+
+      return false;
+    },
+    /**
+     * Closes current polygon and unites it with current annotaiton.
+     * @returns {boolean} sucessfully closes object
+     */
+    complete() {
+      if (this.polygon.path == null) return false;
+
+      this.removeLastPoint();
+
+      this.polygon.path.fillColor = "black";
+      this.polygon.path.closePath();
+
+      this.$parent.uniteCurrentAnnotation(this.polygon.path);
+
+      this.polygon.path.remove();
+      this.polygon.path = null;
+      if (this.color.circle) {
+        this.color.circle.remove();
+        this.color.circle = null;
+      }
+
+      this.removeUndos(this.actionTypes.ADD_POINTS);
+      return true;
+    },
+    removeLastPoint() {
+      this.polygon.path.removeSegment(this.polygon.path.segments.length - 1);
+    }
+  },
+  computed: {
+    isDisabled() {
+      return this.$parent.current.annotation === -1;
+    }
+  },
+  watch: {
+    isActive(active) {
+      if (active) {
+        this.tool.activate();
+        localStorage.setItem("editorTool", this.name);
+      }
+    },
+    /**
+     * Change width of stroke based on zoom of image
+     */
+    scale(newScale) {
+      this.polygon.pathOptions.strokeWidth = newScale * this.scaleFactor;
+      if (this.polygon.path != null)
+        this.polygon.path.strokeWidth = newScale * this.scaleFactor;
+    },
+    /**
+     * Remove last point (point were mouse was) if enable guidane
+     */
+    "polygon.guidance"(guidance) {
+      if (this.polygon.path == null) return;
+
+      if (!guidance && this.polygon.path.length > 1) {
+        this.removeLastPoint();
+      }
+    },
+    "polygon.minDistance"(newDistance) {
+      this.tool.minDistance = newDistance;
+    },
+    "polygon.pathOptions.strokeColor"(newColor) {
+      if (this.polygon.path == null) return;
+
+      this.polygon.path.strokeColor = newColor;
+    },
+    "color.auto"(value) {
+      if (value && this.polygon.path) {
+        this.color.circle = new paper.Path.Circle(
+          new paper.Point(0, 0),
+          this.color.radius
+        );
+      }
+      if (!value && this.color.circle) {
+        this.color.circle.remove();
+        this.color.circle = null;
+      }
+    }
+  },
+  created() {},
+  mounted() {
+    this.tool.minDistance = this.minDistance;
+  }
+};
+</script>

--- a/client/src/components/annotator/tools/SelectTool.vue
+++ b/client/src/components/annotator/tools/SelectTool.vue
@@ -198,6 +198,7 @@ export default {
         this.moveObject = event.item;
         paperObject = event.item;
       }
+      console.log(paperObject, path);
       this.isBbox = this.checkBbox(paperObject);
       if (this.point != null) {
         this.edit.canMove = this.point.contains(event.point);
@@ -232,12 +233,11 @@ export default {
       if(this.isBbox && this.moveObject){
         let delta_x = this.initPoint.x - event.point.x;
         let delta_y = this.initPoint.y - event.point.y;
-        let segment = this.moveObject.firstSegment;
-        for(let i = 0; i<4;i++){
+        let segments = this.moveObject.children[0].segments;
+        segments.forEach( segment => {
           let p = segment.point;
           segment.point = new paper.Point(p.x - delta_x, p.y - delta_y);
-          segment = segment.next;
-        }
+        });
         this.initPoint = event.point;
       }
       if (this.segment && this.edit.canMove) {

--- a/client/src/components/annotator/tools/SelectTool.vue
+++ b/client/src/components/annotator/tools/SelectTool.vue
@@ -45,7 +45,7 @@ export default {
         segments: true,
         stroke: true,
         fill: false,
-        tolerance: 5,
+        tolerance: 10,
         match: hit => {
           return !hit.item.hasOwnProperty("indicator");
         }
@@ -179,12 +179,15 @@ export default {
       }
 
       let path = hitResult.item;
-
       if (hitResult.type === "segment") {
         this.segment = hitResult.segment;
       } else if (hitResult.type === "stroke") {
         let location = hitResult.location;
         this.segment = path.insert(location.index + 1, event.point);
+      } else if (event.item.className == "CompoundPath"){
+        this.initPoint = event.point;
+        this.moveObject = event.item;
+        console.log("we're moving objects bitch");
       }
 
       if (this.point != null) {
@@ -197,7 +200,7 @@ export default {
       this.hover.category = null;
       this.hover.annotation = null;
       this.segment = null;
-
+      this.moveObject = null;
       if (this.hover.text != null) {
         this.hover.text.remove();
         this.hover.box.remove();
@@ -216,6 +219,17 @@ export default {
       this.point.indicator = true;
     },
     onMouseDrag(event) {
+      if(this.moveObject){
+        let delta_x = this.initPoint.x - event.point.x;
+        let delta_y = this.initPoint.y - event.point.y;
+        let segment = this.moveObject.firstSegment;
+        for(let i = 0; i<4;i++){
+          let p = segment.point;
+          segment.point = new paper.Point(p.x - delta_x, p.y - delta_y);
+          segment = segment.next;
+        }
+        this.initPoint = event.point;
+      }
       this.bbox = true;
       if (this.segment && this.edit.canMove) {
         this.createPoint(event.point);

--- a/client/src/components/annotator/tools/SelectTool.vue
+++ b/client/src/components/annotator/tools/SelectTool.vue
@@ -196,6 +196,7 @@ export default {
     clear() {
       this.hover.category = null;
       this.hover.annotation = null;
+      this.segment = null;
 
       if (this.hover.text != null) {
         this.hover.text.remove();
@@ -210,16 +211,31 @@ export default {
       }
 
       this.point = new paper.Path.Circle(point, this.edit.indicatorSize);
-      this.point.strokeColor = "white";
+      this.point.strokeColor = "black";
       this.point.strokeWidth = this.edit.indicatorWidth;
       this.point.indicator = true;
     },
     onMouseDrag(event) {
+      this.bbox = true;
       if (this.segment && this.edit.canMove) {
         this.createPoint(event.point);
+        if(this.bbox){
+          //counter clockwise prev and next.
+          let isCounterClock = this.segment.previous.point.x == this.segment.point.x;
+          let prev = isCounterClock ? this.segment.previous : this.segment.next;
+          let next = !isCounterClock ? this.segment.previous : this.segment.next;
+          
+          prev.point = new paper.Point(event.point.x, prev.point.y);
+          next.point = new paper.Point(next.point.x, event.point.y); 
+        }//getbbox here somehow
         this.segment.point = event.point;
+        
       }
     },
+
+    // .---.
+    // |   |
+    // .___.
     onMouseMove(event) {
       let hitResult = this.$parent.paper.project.hitTest(
         event.point,

--- a/client/src/components/cards/DatasetCard.vue
+++ b/client/src/components/cards/DatasetCard.vue
@@ -180,6 +180,7 @@
                 <TagsInput
                   v-model="sharedUsers"
                   element-id="usersList"
+                  :existing-tags="users"
                   :typeahead="true"
                   :typeahead-activation-threshold="0"
                   placeholder="Add usernames"
@@ -238,7 +239,7 @@ export default {
       defaultMetadata: this.dataset.default_annotation_metadata,
       noImageUrl: require("@/assets/no-image.png"),
       notFoundImageUrl: require("@/assets/404-image.png"),
-      sharedUsers: this.dataset.users
+      sharedUsers: []
     };
   },
   methods: {
@@ -248,6 +249,7 @@ export default {
       this.$router.push({ name: "dataset", params: { identifier } });
     },
     onShare() {
+      this.dataset.users = this.sharedUsers;
       axios
         .post("/api/dataset/" + this.dataset.id + "/share", {
           users: this.sharedUsers
@@ -343,8 +345,13 @@ export default {
 
       return tags;
     },
-    user() {
-      return this.$store.state.user.user;
+    users() {
+      let users = {};
+      this.$parent.users.forEach(user => {
+        users[user.username] = user.username;
+      });
+
+      return users;
     }
   },
   mounted() {

--- a/client/src/libs/bbox.js
+++ b/client/src/libs/bbox.js
@@ -1,0 +1,47 @@
+class Point{
+    constructor(point) {
+        this.x = point.x;
+        this.y = point.y;
+    }
+}
+
+export class BBox {
+    constructor(point) {
+        this.point1 = new Point(point); //one corner point.
+        this.point2 = null;
+    }
+    
+    addPoint(point){
+        this.point2 = new Point(point);
+        this.point1_2 = new Point({x: this.point1.x, y: this.point2.y});
+        this.point2_1 = new Point({x: this.point2.x, y: this.point1.y});
+    }
+
+    modifyPoint(point){
+        this.point2 = null;
+        this.addPoint(point);
+    }
+
+    getPoints(){
+        if(!this.isComplete()){
+            return [this.point1];
+        }
+        var points = [];
+        points[0] = this.point1;
+        points[1] = this.point1_2;
+        points[2] = this.point2;
+        points[3] = this.point2_1;
+        points[4] = this.point1;
+        return points;
+    }
+
+    removePoint() {
+        this.point2 = null;
+        this.point1_2 = null;
+        this.point2_1 = null;
+    }
+
+    isComplete() {
+        return !!this.point2;
+    }
+}

--- a/client/src/mixins/shortcuts.js
+++ b/client/src/mixins/shortcuts.js
@@ -134,10 +134,10 @@ export default {
           function: this.save
         },
         {
-          title: "Polygon Tool Shortcuts",
+          title: "BBox Tool Shortcuts",
           default: ["escape"],
-          name: "Remove Current Polygon",
-          function: this.$refs.polygon.deletePolygon
+          name: "Remove Current BBox",
+          function: this.$refs.bbox.deletePolygon
         },
         {
           title: "Eraser Tool Shortcuts",

--- a/client/src/mixins/shortcuts.js
+++ b/client/src/mixins/shortcuts.js
@@ -70,12 +70,19 @@ export default {
           }
         },
         {
-          default: ["p"],
-          name: "Polygon Tool",
+          default: ["r"],
+          name: "BBox Tool",
           function: () => {
-            if (!this.$refs.polygon.isDisabled) this.activeTool = "Polygon";
+            if (!this.$refs.polygon.isDisabled) this.activeTool = "BBox";
           }
         },
+        // {
+        //   default: ["p"],
+        //   name: "Polygon Tool",
+        //   function: () => {
+        //     if (!this.$refs.polygon.isDisabled) this.activeTool = "Polygon";
+        //   }
+        // },
         {
           default: ["w"],
           name: "Magic Wand Tool",

--- a/client/src/mixins/shortcuts.js
+++ b/client/src/mixins/shortcuts.js
@@ -76,13 +76,24 @@ export default {
             if (!this.$refs.polygon.isDisabled) this.activeTool = "BBox";
           }
         },
-        // {
-        //   default: ["p"],
-        //   name: "Polygon Tool",
-        //   function: () => {
-        //     if (!this.$refs.polygon.isDisabled) this.activeTool = "Polygon";
-        //   }
-        // },
+        {
+          default: ["n"],
+          name: "Next Image",
+          function: this.nextImage
+        },
+        {
+          default: ["p"],
+          name: "Previous Image",
+          function: this.previousImage
+        },
+        {
+          default: ["v"],
+          name: "Polygon Tool",
+          function: () => {
+            if (!this.$refs.polygon.isDisabled) this.activeTool = "Polygon";
+          }
+        },
+        
         {
           default: ["w"],
           name: "Magic Wand Tool",

--- a/client/src/views/Annotator.vue
+++ b/client/src/views/Annotator.vue
@@ -13,14 +13,14 @@
         />
         <hr />
 
-        <!-- <PolygonTool
+        <BBoxTool
           v-model="activeTool"
           :scale="image.scale"
           @setcursor="setCursor"
-          ref="polygon"
-        /> -->
+          ref="bbox"
+        />
 
-        <BBoxTool
+        <PolygonTool
           v-model="activeTool"
           :scale="image.scale"
           @setcursor="setCursor"
@@ -100,6 +100,7 @@
         :previousimage="image.previous"
         :nextimage="image.next"
         :filename="image.filename"
+        ref="filetitle"
       />
 
       <div v-if="categories.length > 5">
@@ -160,8 +161,11 @@
         <h6 class="sidebar-title text-center">{{ activeTool }}</h6>
 
         <div class="tool-section" style="max-height: 30%; color: lightgray">
+          <div v-if="$refs.bbox != null">
+            <BBoxPanel :bbox="$refs.bbox" />
+          </div>
           <div v-if="$refs.polygon != null">
-            <PolygonPanel :polygon="$refs.polygon" />
+            <PolygonPanel :polygon="$refs.polybboxgon" />
           </div>
 
           <div v-if="$refs.select != null">
@@ -226,7 +230,7 @@ import Category from "@/components/annotator/Category";
 import Label from "@/components/annotator/Label";
 import Annotations from "@/models/annotations";
 
-// import PolygonTool from "@/components/annotator/tools/PolygonTool";
+import PolygonTool from "@/components/annotator/tools/PolygonTool";
 import BBoxTool from "@/components/annotator/tools/BBoxTool";
 import SelectTool from "@/components/annotator/tools/SelectTool";
 import MagicWandTool from "@/components/annotator/tools/MagicWandTool";
@@ -248,6 +252,7 @@ import HideAllButton from "@/components/annotator/tools/HideAllButton";
 import AnnotateButton from "@/components/annotator/tools/AnnotateButton";
 
 import PolygonPanel from "@/components/annotator/panels/PolygonPanel";
+import BBoxPanel from "@/components/annotator/panels/BBoxPanel";
 import SelectPanel from "@/components/annotator/panels/SelectPanel";
 import MagicWandPanel from "@/components/annotator/panels/MagicWandPanel";
 import BrushPanel from "@/components/annotator/panels/BrushPanel";
@@ -264,8 +269,9 @@ export default {
     CopyAnnotationsButton,
     Category,
     CLabel: Label,
-    // PolygonTool,
     BBoxTool,
+    BBoxPanel,
+    PolygonTool,
     PolygonPanel,
     SelectTool,
     MagicWandTool,
@@ -773,6 +779,14 @@ export default {
       if (index > -1) {
         this.annotating.splice(index, 1);
       }
+    },
+    nextImage() {
+      if(this.image.next != null)
+        this.$refs.filetitle.route(this.image.next);
+    },
+    previousImage() {
+      if(this.image.previous != null)
+        this.$refs.filetitle.route(this.image.previous);
     }
   },
   watch: {

--- a/client/src/views/Annotator.vue
+++ b/client/src/views/Annotator.vue
@@ -165,7 +165,7 @@
             <BBoxPanel :bbox="$refs.bbox" />
           </div>
           <div v-if="$refs.polygon != null">
-            <PolygonPanel :polygon="$refs.polybboxgon" />
+            <PolygonPanel :polygon="$refs.polygon" />
           </div>
 
           <div v-if="$refs.select != null">
@@ -368,6 +368,7 @@ export default {
       let data = {
         mode: this.mode,
         user: {
+          bbox: this.$refs.bbox.export(),
           polygon: this.$refs.polygon.export(),
           eraser: this.$refs.eraser.export(),
           brush: this.$refs.brush.export(),
@@ -530,6 +531,7 @@ export default {
     setPreferences(preferences) {
       let refs = this.$refs;
 
+      refs.bbox.setPreferences(preferences.bbox || {});
       refs.polygon.setPreferences(preferences.polygon || {});
       refs.select.setPreferences(preferences.select || {});
       refs.magicwand.setPreferences(preferences.magicwand || {});

--- a/client/src/views/Annotator.vue
+++ b/client/src/views/Annotator.vue
@@ -531,7 +531,7 @@ export default {
     setPreferences(preferences) {
       let refs = this.$refs;
 
-      refs.bbox.setPreferences(preferences.bbox || {});
+      refs.bbox.setPreferences(preferences.bbox || preferences.polygon || {});
       refs.polygon.setPreferences(preferences.polygon || {});
       refs.select.setPreferences(preferences.select || {});
       refs.magicwand.setPreferences(preferences.magicwand || {});

--- a/client/src/views/Annotator.vue
+++ b/client/src/views/Annotator.vue
@@ -603,9 +603,9 @@ export default {
       return this.$refs.category[index];
     },
     // Current Annotation Operations
-    uniteCurrentAnnotation(compound, simplify = true, undoable = true) {
+    uniteCurrentAnnotation(compound, simplify = true, undoable = true, isBBox = false) {
       if (this.currentAnnotation == null) return;
-      this.currentAnnotation.unite(compound, simplify, undoable);
+      this.currentAnnotation.unite(compound, simplify, undoable, isBBox);
     },
     subtractCurrentAnnotation(compound, simplify = true, undoable = true) {
       if (this.currentCategory == null) return;

--- a/client/src/views/Annotator.vue
+++ b/client/src/views/Annotator.vue
@@ -13,12 +13,20 @@
         />
         <hr />
 
-        <PolygonTool
+        <!-- <PolygonTool
+          v-model="activeTool"
+          :scale="image.scale"
+          @setcursor="setCursor"
+          ref="polygon"
+        /> -->
+
+        <BBoxTool
           v-model="activeTool"
           :scale="image.scale"
           @setcursor="setCursor"
           ref="polygon"
         />
+
         <MagicWandTool
           v-model="activeTool"
           :width="image.raster.width"
@@ -218,7 +226,8 @@ import Category from "@/components/annotator/Category";
 import Label from "@/components/annotator/Label";
 import Annotations from "@/models/annotations";
 
-import PolygonTool from "@/components/annotator/tools/PolygonTool";
+// import PolygonTool from "@/components/annotator/tools/PolygonTool";
+import BBoxTool from "@/components/annotator/tools/BBoxTool";
 import SelectTool from "@/components/annotator/tools/SelectTool";
 import MagicWandTool from "@/components/annotator/tools/MagicWandTool";
 import EraserTool from "@/components/annotator/tools/EraserTool";
@@ -255,7 +264,8 @@ export default {
     CopyAnnotationsButton,
     Category,
     CLabel: Label,
-    PolygonTool,
+    // PolygonTool,
+    BBoxTool,
     PolygonPanel,
     SelectTool,
     MagicWandTool,

--- a/client/src/views/Categories.vue
+++ b/client/src/views/Categories.vue
@@ -121,7 +121,9 @@
           </div>
           <div class="modal-body">
             More information can be found in the
-            <a href="/help">help section</a>.
+            <a href="https://github.com/jsbroks/coco-annotator/wiki/Usage#creating-categories">
+              getting started section
+            </a>.
             <hr />
             <h6>What is a category?</h6>
 

--- a/client/src/views/Datasets.vue
+++ b/client/src/views/Datasets.vue
@@ -184,6 +184,7 @@
 <script>
 import toastrs from "@/mixins/toastrs";
 import Datasets from "@/models/datasets";
+import AdminPanel from "@/models/admin";
 import DatasetCard from "@/components/cards/DatasetCard";
 import Pagination from "@/components/Pagination";
 import TagsInput from "@/components/TagsInput";
@@ -205,7 +206,8 @@ export default {
       },
       datasets: [],
       subdirectories: [],
-      categories: []
+      categories: [],
+      users: []
     };
   },
   methods: {
@@ -220,15 +222,18 @@ export default {
       Datasets.allData({
         limit: this.limit,
         page: page
-      })
-        .then(response => {
-          this.datasets = response.data.datasets;
-          this.categories = response.data.categories;
-          this.subdirectories = response.data.subdirectories;
-          this.pages = response.data.pagination.pages;
-          this.page = response.data.pagination.page;
-        })
-        .finally(() => this.removeProcess(process));
+      }).then(response => {
+        this.datasets = response.data.datasets;
+        this.categories = response.data.categories;
+        this.subdirectories = response.data.subdirectories;
+        this.pages = response.data.pagination.pages;
+        this.page = response.data.pagination.page;
+        AdminPanel.getUsers(this.limit)
+          .then(response => {
+            this.users = response.data.users;
+          })
+          .finally(() => this.removeProcess(process));
+      });
     },
     createDataset() {
       if (this.create.name.length < 1) return;


### PR DESCRIPTION
This tool allows to segment the images in the bounding box fashion, and some extra functionality, as mentioned in closes #164 .

There are a couple of assumptions:

1. Only one bounding box per annotation instance.
2. The bounding box co-ordinates(4 corners) can be found under segmentation attribute of the annotation in one of permutation of the following array. `[UpperLeft, UpperRight, BottomRight, BottomLeft]`, though opposing corners are always stored 2 indices apart. Such as if `UpperLeft` is at index 0 then `BottomRight` will be on  index 2.

This feature also adds some additional functionality to `SelectTool` such as:

1. You can now move the annotated bounding box, In future I'll try to add this functionality for polygon as well.
2. You can resize the bounding box in bounding box fashion.
