### PR TITLE
Deletes annotations via eraser tool

### DIFF
--- a/client/src/components/annotator/Annotation.vue
+++ b/client/src/components/annotator/Annotation.vue
@@ -437,6 +437,10 @@ export default {
       this.addUndo(action);
     },
     simplifyPath() {
+      if (this.compoundPath != null && this.compoundPath.isEmpty()) {
+          this.deleteAnnotation();
+          return;
+      }
       let simplify = this.simplify;
 
       this.compoundPath.flatten(1);


### PR DESCRIPTION
This fixes https://github.com/jsbroks/coco-annotator/issues/169 by deleting annotations that are completely erased with the eraser tool on mouse up. 

I tested this on the development build and found that it works by generating annotations and erasing them. Before the annotations would hang around as empty annotations and a point in the center would appear after erasing an annotation. Annotation IDs are reordered correctly as well when annotations are deleted.