### PR TITLE
Add dataset specific category counts to statistics tab

### DIFF
--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -138,6 +138,22 @@
                 </div>
               </div>
 
+              <div v-if="stats.categories" class="card my-3 p-3 shadow-sm col-4 mr-2">
+                <h6 class="border-bottom border-gray pb-2"><b>Annotations Per Category</b></h6>
+                <div class="row" v-for="stat in Object.keys(stats.categories)">
+                  <strong class="col-8">{{stat}}:</strong>
+                  <span class="col-4">{{stats.categories[stat].toFixed(0)}}</span>
+                </div>
+              </div>
+
+              <div v-if="stats.images_per_category" class="card my-3 p-3 shadow-sm col-4 mr-2">
+                <h6 class="border-bottom border-gray pb-2"><b>Annotated Images Per Category</b></h6>
+                <div class="row" v-for="stat in Object.keys(stats.images_per_category)">
+                  <strong class="col-8">{{stat}}:</strong>
+                  <span class="col-4">{{stats.images_per_category[stat].toFixed(0)}}</span>
+                </div>
+              </div>
+
             </div>
             
           </div>


### PR DESCRIPTION
This feature helps users determine how many annotations they have in each category within a specific dataset. In the current release, category specific counts are only available on the categories tab and they do not have a breakdown per dataset. This pull request adds both annotation and annotated image counts for each category to the datasets statistics tab