### PR TITLE
Improve loading speed for image cards

### DIFF
--- a/backend/database/images.py
+++ b/backend/database/images.py
@@ -103,14 +103,8 @@ class ImageModel(DynamicDocument):
             pil_image = self.generate_thumbnail()
             pil_image = pil_image.convert("RGB")
 
-            # Calculate resize ratio:
-            resize_ratio = min(1, self.MAX_THUMBNAIL_DIM[0] / pil_image.height,
-                               self.MAX_THUMBNAIL_DIM[1] / pil_image.width)
-
-            # Resize the image if it is larger than the maximum size specified by MAX_THUMBNAIL_DIM
-            if resize_ratio < 1:
-                pil_image = pil_image.resize((int(resize_ratio * pil_image.width),
-                                              int(resize_ratio * pil_image.height)))
+            # Resize image to fit in MAX_THUMBNAIL_DIM envelope as necessary
+            pil_image = pil_image.thumbnail((self.MAX_THUMBNAIL_DIM[1], self.MAX_THUMBNAIL_DIM[0]))
 
             # Save as a jpeg to improve loading time
             # (note file extension will not match but allows for backwards compatibility)

--- a/backend/database/images.py
+++ b/backend/database/images.py
@@ -104,7 +104,7 @@ class ImageModel(DynamicDocument):
             pil_image = pil_image.convert("RGB")
 
             # Resize image to fit in MAX_THUMBNAIL_DIM envelope as necessary
-            pil_image = pil_image.thumbnail((self.MAX_THUMBNAIL_DIM[1], self.MAX_THUMBNAIL_DIM[0]))
+            pil_image.thumbnail((self.MAX_THUMBNAIL_DIM[1], self.MAX_THUMBNAIL_DIM[0]))
 
             # Save as a jpeg to improve loading time
             # (note file extension will not match but allows for backwards compatibility)

--- a/backend/webserver/api/annotator.py
+++ b/backend/webserver/api/annotator.py
@@ -128,7 +128,7 @@ class AnnotatorData(Resource):
             set__metadata=image.get('metadata', {}),
             set__annotated=annotated,
             set__category_ids=image.get('category_ids', []),
-            set__regenerate_thumbnail=annotated,
+            set__regenerate_thumbnail=True,
             set__num_annotations=annotations\
                 .filter(deleted=False, area__gt=0).count()
         )

--- a/client/src/components/cards/ImageCard.vue
+++ b/client/src/components/cards/ImageCard.vue
@@ -146,7 +146,7 @@ export default {
   computed: {
     imageUrl() {
       let d = new Date();
-      if (this.image.annotated && this.showAnnotations) {
+      if (this.showAnnotations) {
         return `/api/image/${
           this.image.id
         }?width=250&thumbnail=true&dummy=${d.getTime()}`;


### PR DESCRIPTION
Current loading speeds of the dataset page can be quite slow when using high resolution images. This greatly improves loading speed for image cards on dataset page by resizing and compressing thumbnail images to a maximum allowable image size. It also uses this smaller thumbnail image for both annotated and non-annotated images.