### PR TITLE
added drag to pan functionality on SelectTool

### DIFF
--- a/client/src/components/annotator/tools/SelectTool.vue
+++ b/client/src/components/annotator/tools/SelectTool.vue
@@ -253,6 +253,17 @@ export default {
         this.segment.point = event.point;
         
       }
+      else {
+        // the event point exists on a relative coordinate system (dependent on screen dimensions) 
+        // however, the image on the canvas paper exists on an absolute coordinate system
+        // thus, tracking mouse deltas from the previous point is necessary
+        let delta_x = this.initPoint.x - event.point.x;
+        let delta_y = this.initPoint.y - event.point.y;
+        let center_delta = new paper.Point(delta_x, delta_y);
+        let new_center = this.$parent.paper.view.center.add(center_delta);
+        this.$parent.paper.view.setCenter(new_center);
+      }
+      
     },
 
     onMouseUp(event){
@@ -260,6 +271,10 @@ export default {
     },
     
     onMouseMove(event) {
+      // ensures that the initPoint is always tracked. 
+      // Necessary for the introduced pan functionality and fixes a bug with selecting and dragging bboxes, since initPoint is initially undefined
+      this.initPoint = event.point;  
+
       let hitResult = this.$parent.paper.project.hitTest(
         event.point,
         this.hitOptions


### PR DESCRIPTION
Highly frustrating to annotate large images without a drag to pan functionality. Though it is available in the onwheel() call in client/src/views/Annotator.vue, it only allows slow pans from left to right, top to bottom.

This introduces a more intuitive and "normal" way to pan the image by clicking and dragging it as you would be able to do in regular applications. You just drag the image around with your mouse.

This has a side effect of fixing a bug introduced in the onMouseDrag function by the code to drag around bounding boxes (lines 233, 234 in this commit). There, it is possible for this.initPoint to be used improperly in two ways.

1.  referenced while it is not yet defined
2. only tracked during mouseDrag events, so dragging a bounding box, lifting your mouse, and dragging another bounding box will not work as intended.

Instead, initPoint is now constantly tracked on mouse movement, fixing the behavior and enabling proper panning behavior too.

