### PR TITLE
Spread Operator (inexplicably) Failing on keypoint edges

### DIFF
--- a/client/src/components/KeypointsDefinition.vue
+++ b/client/src/components/KeypointsDefinition.vue
@@ -277,13 +277,13 @@ export default {
           let kp_edges = new Set(kp.edges);
           if (!new_edges.has(kp.label) && kp_edges.has(current_kp.label)) {
             kp_edges.delete(current_kp.label);
-            kp.edges = [...kp_edges];
+            kp.edges = Array.from(kp_edges);
           } else if (
             new_edges.has(kp.label) &&
             !kp_edges.has(current_kp.label)
           ) {
             kp_edges.add(current_kp.label);
-            kp.edges = [...kp_edges];
+            kp.edges = Array.from(kp_edges);
           }
           if (kp.edges.length === 0 && kp.label.length === 0 && kp.label_error) {
             kp.label_error = "";


### PR DESCRIPTION
I think this resolves #354 

The issue seems to be with this function https://github.com/jsbroks/coco-annotator/blob/c7092966b481dd2900a55352d39659cc3e337528/client/src/components/KeypointsDefinition.vue#L270-L292

For reasons that I don't understand when building from `docker-compose.yml` or `docker-compose.build.yml` when attempting to add connected edges it fails with the following error.

![error](https://user-images.githubusercontent.com/1112365/78152722-2fe02300-7408-11ea-8080-78f214db6fca.png)

`Invalid attempt to spread non-iterable instance`.

When I read and even debug the code everything appears correct, and it works with `docker-compose.dev.yml`. My only theory is that it is some sort of weird webpack/babel transpilation issue? 

The bandaid solution is to use `Array.from` instead of the spread operator. I'd prefer to have gotten the spread operator to work from an aesthetic perspective, but this works for now until somebody has some better insight.
