### PR TITLE
Add directory support to file watcher (Issue #374)

### DIFF
--- a/backend/webserver/watcher.py
+++ b/backend/webserver/watcher.py
@@ -17,11 +17,18 @@ class ImageFolderHandler(FileSystemEventHandler):
     def on_any_event(self, event):
 
         path = event.dest_path if event.event_type == "moved" else event.src_path
-                
+
+        if event.is_directory:
+            # Listen to directory events as some file systems don't generate
+            # per-file `deleted` events when moving/deleting directories
+            if event.event_type == 'deleted':
+                self._log(f'Deleting images from database {path}')
+                ImageModel.objects(path=re.compile('^' + re.escape(path))).delete()
+            return
+
         if (
-            event.is_directory
             # check if its a hidden file
-            or bool(re.search(r'\/\..*?\/', path))
+            bool(re.search(r'\/\..*?\/', path))
             or not path.lower().endswith(self.pattern)
         ):
             return


### PR DESCRIPTION
Listen to delete events on directories and delete images accordingly.

The exact details differ from file system to file system. On macOS (which is the only os I have done thorough testing on) this solves problems arising from using Finder to delete directories and move sub-directories. These events would previously not register and would cause the database to be filled with "zombie"-images.

Previously
```bash
$ tree
.
├── dir1
│   └── dir11
│       └── i.png
└── dir2

3 directories, 1 file
$ mv dir1/dir11 dir2/ 
```
would yield two duplicate database entries (`dir1/dir11/i.png` and `dir2/dir11/i.png`). This will now produce one database entry with path `dir2/dir11/i.png`.