### PR TITLE
Annotate bbox

### DIFF
--- a/client/src/components/annotator/tools/AnnotateButton.vue
+++ b/client/src/components/annotator/tools/AnnotateButton.vue
@@ -63,11 +63,13 @@ export default {
               let keypoints = annotation.keypoints || [];
               let segmentation = annotation.segmentation || [];
               let category = indexedCategories[annotation.category_id];
+              let isbbox = annotation.isbbox || false;
 
               this.$parent.addAnnotation(
                 category.name,
                 segmentation,
-                keypoints
+                keypoints,
+                isbbox=isbbox
               );
             });
           })

--- a/client/src/views/Annotator.vue
+++ b/client/src/views/Annotator.vue
@@ -864,7 +864,7 @@ export default {
       if (!categoryComponent) return null;
       return categoryComponent.category;
     },
-    addAnnotation(categoryName, segments, keypoints) {
+    addAnnotation(categoryName, segments, keypoints, isbbox=false) {
       segments = segments || [];
       keypoints = keypoints || [];
 
@@ -877,7 +877,8 @@ export default {
         image_id: this.image.id,
         category_id: category.id,
         segmentation: segments,
-        keypoints: keypoints
+        keypoints: keypoints,
+        isbbox: isbbox
       }).then(response => {
         let annotation = response.data;
         category.annotations.push(annotation);


### PR DESCRIPTION
This PR will allow endpoints that return the `isbbox` parameter to annotate boxes instead of masks. This is useful for people building detection datasets.

Now, when `AnnotateButton` reads the post response, if `isbbox` is set in `annotations`, it passes it to `addAnnotation` that calls the API with the `isbbox` parameter. If `isbbox` is not present in the response, `AnnotateButton` sets `isbbox=false`. The default value of `isbbox` in `addAnnotation` is `false`, too.

Resolves jsbroks/coco-annotator#386
