### PR TITLE
enable exporting un-annotated img

### DIFF
--- a/backend/database/datasets.py
+++ b/backend/database/datasets.py
@@ -64,7 +64,7 @@ class DatasetModel(DynamicDocument):
             "name": task.name
         }
 
-    def export_coco(self, categories=None, style="COCO"):
+    def export_coco(self, categories=None, style="COCO", with_empty_images=False):
 
         from workers.tasks import export_annotations
 
@@ -78,7 +78,7 @@ class DatasetModel(DynamicDocument):
         )
         task.save()
 
-        cel_task = export_annotations.delay(task.id, self.id, categories)
+        cel_task = export_annotations.delay(task.id, self.id, categories, with_empty_images)
 
         return {
             "celery_id": cel_task.id,

--- a/backend/webserver/api/datasets.py
+++ b/backend/webserver/api/datasets.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restplus import Namespace, Resource, reqparse
+from flask_restplus import Namespace, Resource, reqparse, inputs
 from flask_login import login_required, current_user
 from werkzeug.datastructures import FileStorage
 from mongoengine.errors import NotUniqueError
@@ -46,6 +46,7 @@ coco_upload.add_argument('coco', location='files', type=FileStorage, required=Tr
 
 export = reqparse.RequestParser()
 export.add_argument('categories', type=str, default=None, required=False, help='Ids of categories to export')
+export.add_argument('with_empty_images', type=inputs.boolean, default=False, required=False, help='Export with un-annotated images')
 
 update_dataset = reqparse.RequestParser()
 update_dataset.add_argument('categories', location='json', type=list, help="New list of categories")
@@ -497,6 +498,7 @@ class DatasetExport(Resource):
 
         args = export.parse_args()
         categories = args.get('categories')
+        with_empty_images = args.get('with_empty_images', False)
         
         if len(categories) == 0:
             categories = []
@@ -509,7 +511,7 @@ class DatasetExport(Resource):
         if not dataset:
             return {'message': 'Invalid dataset ID'}, 400
         
-        return dataset.export_coco(categories=categories)
+        return dataset.export_coco(categories=categories, with_empty_images=with_empty_images)
     
     @api.expect(coco_upload)
     @login_required

--- a/backend/webserver/api/images.py
+++ b/backend/webserver/api/images.py
@@ -2,6 +2,7 @@ from flask_restplus import Namespace, Resource, reqparse
 from flask_login import login_required, current_user
 from werkzeug.datastructures import FileStorage
 from flask import send_file
+from mongoengine.errors import NotUniqueError
 
 from ..util import query_util, coco_util
 from database import (
@@ -95,7 +96,10 @@ class Images(Resource):
 
         image.close()
         pil_image.close()
-        db_image = ImageModel.create_from_path(path, dataset_id).save()
+        try:
+            db_image = ImageModel.create_from_path(path, dataset_id).save()
+        except NotUniqueError:
+            db_image = ImageModel.objects.get(path=path)
         return db_image.id
 
 

--- a/backend/workers/tasks/data.py
+++ b/backend/workers/tasks/data.py
@@ -21,7 +21,7 @@ from mongoengine import Q
 
 
 @shared_task
-def export_annotations(task_id, dataset_id, categories):
+def export_annotations(task_id, dataset_id, categories, with_empty_images=False):
 
     task = TaskModel.objects.get(id=task_id)
     dataset = DatasetModel.objects.get(id=dataset_id)
@@ -83,6 +83,8 @@ def export_annotations(task_id, dataset_id, categories):
         annotations = fix_ids(annotations)
 
         if len(annotations) == 0:
+            if with_empty_images:
+                coco.get('images').append(image)
             continue
 
         num_annotations = 0

--- a/client/src/models/datasets.js
+++ b/client/src/models/datasets.js
@@ -30,8 +30,8 @@ export default {
   scan(id) {
     return axios.get(`${baseURL}/${id}/scan`);
   },
-  exportingCOCO(id, categories) {
-    return axios.get(`${baseURL}/${id}/export?categories=${categories}`);
+  exportingCOCO(id, categories, with_empty_images) {
+    return axios.get(`${baseURL}/${id}/export?categories=${categories}&with_empty_images=${with_empty_images}`);
   },
   getCoco(id) {
     return axios.get(`${baseURL}/${id}/coco`);

--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -418,6 +418,11 @@
                   :typeahead-activation-threshold="0"
                 ></TagsInput>
               </div>
+              <div>
+                <input type="checkbox" class="form-check-input"
+                  v-model="exporting.with_empty_images">
+                <label class="form-check-label">export with not annotated images</label>
+              </div>
             </form>
           </div>
           <div class="modal-footer">
@@ -514,6 +519,7 @@ export default {
       exporting: {
         categories: [],
         progress: 0,
+        with_empty_images: false,
         id: null
       },
       selected: {
@@ -637,7 +643,7 @@ export default {
     },
     exportCOCO() {
       $("#exportDataset").modal("hide");
-      Dataset.exportingCOCO(this.dataset.id, this.exporting.categories)
+      Dataset.exportingCOCO(this.dataset.id, this.exporting.categories, this.exporting.with_empty_images)
         .then(response => {
           let id = response.data.id;
           this.exporting.id = id;


### PR DESCRIPTION
1) Sometimes un-annotated img means obj of interests just doesn't exist. So I enabled exporting them with an option added.

2) https://github.com/jsbroks/coco-annotator/pull/448
In the above added feature I made several days ago,  
If we leave FILE_WATCHER to true in docker-composer.yml,   
after file upload, sometimes the watcher will register the image to DB before our code.  
So there need to be a try and catch.