### PR TITLE
Improvement: Remember labelling mode

### DIFF
--- a/client/src/components/annotator/FileTitle.vue
+++ b/client/src/components/annotator/FileTitle.vue
@@ -4,13 +4,13 @@
       v-show="previousimage != null"
       class="fa fa-arrow-left image-arrows"
       style="float:left"
-      @click="route(previousimage)"
+      @click="route(previousimage, labelmode)"
     />
     <i
       v-show="nextimage != null"
       class="fa fa-arrow-right image-arrows"
       style="float:right"
-      @click="route(nextimage)"
+      @click="route(nextimage, labelmode)"
     />
 
     <h6 class="text-center" style="color: white;">
@@ -36,6 +36,10 @@ export default {
     nextimage: {
       type: Number,
       default: null
+    },
+    labelmode: {
+      type: String,
+      required: false
     }
   },
   methods: {
@@ -44,13 +48,13 @@ export default {
      *
      * @param {Number} identifer id of a file
      */
-    route(identifier) {
+    route(identifier, labelmode) {
       // Make sure we pop the latest session before annotations
       this.$parent.current.annotation = -1;
 
       this.$nextTick(() => {
         this.$parent.save(() => {
-          this.$router.push({ name: "annotate", params: { identifier } });
+          this.$router.push({ name: "annotate", params: { identifier, labelmode } });
         });
       });
     }

--- a/client/src/views/Annotator.vue
+++ b/client/src/views/Annotator.vue
@@ -99,6 +99,7 @@
       <FileTitle
         :previousimage="image.previous"
         :nextimage="image.next"
+        :labelmode="this.mode"
         :filename="image.filename"
         ref="filetitle"
       />
@@ -304,6 +305,10 @@ export default {
     identifier: {
       type: [Number, String],
       required: true
+    },
+    labelmode: {
+      type: [String],
+      required: false
     }
   },
   data() {
@@ -313,7 +318,7 @@ export default {
       shapeOpacity: 0.6,
       zoom: 0.2,
       cursor: "move",
-      mode: "segment",
+      mode: this.labelmode || "segment",
       simplify: 1,
       panels: {
         show: {
@@ -919,11 +924,11 @@ export default {
     },
     nextImage() {
       if(this.image.next != null)
-        this.$refs.filetitle.route(this.image.next);
+        this.$refs.filetitle.route(this.image.next, this.mode);
     },
     previousImage() {
       if(this.image.previous != null)
-        this.$refs.filetitle.route(this.image.previous);
+        this.$refs.filetitle.route(this.image.previous, this.mode);
     }
   },
   watch: {


### PR DESCRIPTION
The `Mode` tool in the toolbar in `Annotator` allows users to switch between `segment` and `label` modes, however the user has to click this every time they navigate to the next image if they want to annotate images only with image-level labels. I made a small modification, passing the current `mode` to the route and passing that to `Annotator` props. 

The new behavior is that the annotator "remembers" the annotation mode. This makes sense because it is unlikely that a user would want to label images in a dataset to have mixed label types. This will save a lot of time for people who want to only annotate with image-level labels only. In my use-case, clicking the tool every time was a dealbreaker

The change is really very simple. I attached a video showing the new behavior. Notice that it doesn't switch back to `segment` mode when I navigate to the next/previous image

https://user-images.githubusercontent.com/8341386/133376426-8deb7633-084d-4507-b1a9-f7320e8a09ff.mov


Disclaimer:
I never used vue.js for any project (mostly I'm a react and svelte person), so my understanding is very limited. If I used a bad practice please edit my PR to conform with the project guidelines

