### PR TITLE
Fix SelectTool when zoomed in

### DIFF
--- a/client/src/components/annotator/tools/SelectTool.vue
+++ b/client/src/components/annotator/tools/SelectTool.vue
@@ -45,7 +45,7 @@ export default {
         segments: true,
         stroke: true,
         fill: false,
-        tolerance: 10,
+        tolerance: 0, // The tolerance is scaled depending on the zoom
         match: hit => {
           return !hit.item.hasOwnProperty("indicator");
         }
@@ -372,6 +372,7 @@ export default {
         this.edit.distance = newScale * 40;
         this.edit.indicatorSize = newScale * 10;
         this.edit.indicatorWidth = newScale * 2;
+        this.hitOptions.tolerance = newScale * 10;
 
         if (this.edit.center && this.point != null) {
           this.createPoint(this.edit.center);


### PR DESCRIPTION
As described in issue #269, the SelectTool does not highlight the right point when zoomed in, making it imposible to select the right point and move it. In issue #269 it was suggested to change the hitOptions tolerance to 1. However, a tolerance of 1 makes it harder to select points when not zoomed in. I have created a fix that still uses a tolerance of 10 but this scales with the zoom. So when zoomed in, the tolerance gets smaller. This makes it possible to select points when zoomed in.