### PR TITLE
API: support sending original image file without JPEG compression

### DIFF
--- a/backend/webserver/api/images.py
+++ b/backend/webserver/api/images.py
@@ -37,6 +37,7 @@ image_download.add_argument('asAttachment', type=bool, default=False)
 image_download.add_argument('thumbnail', type=bool, default=False)
 image_download.add_argument('width', type=int)
 image_download.add_argument('height', type=int)
+image_download.add_argument('original', type=bool, default=False)
 
 copy_annotations = reqparse.RequestParser()
 copy_annotations.add_argument('category_ids', location='json', type=list,
@@ -113,11 +114,14 @@ class ImageId(Resource):
         args = image_download.parse_args()
         as_attachment = args.get('asAttachment')
         thumbnail = args.get('thumbnail')
+        original = args.get('original')
 
         image = current_user.images.filter(id=image_id, deleted=False).first()
 
         if image is None:
             return {'success': False}, 400
+        if original:
+            return send_file(image.path, attachment_filename=image.file_name, as_attachment=as_attachment)
 
         width = args.get('width')
         height = args.get('height')


### PR DESCRIPTION
I have some automated tasks, done with COCO Annotator API. Some of them need to download original image file, without compressing image each time I access it. So I've added shortcut in ```/api/images/{id}``` method, so it can take optional parameter `original` (which is set to `False` by default. If `original == True`, than any manipulation with image data is bypassed and original file is sent to response stream. Hope it's useful.