### PR TITLE
Fix rabbitmq version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     networks:
       - cocoannotator
   messageq:
-    image: rabbitmq:3
+    image: rabbitmq:3.7.0
     container_name: annotator_message_q
     environment:
       - RABBITMQ_DEFAULT_USER=user


### PR DESCRIPTION
While the theoretical message size limit in RabbitMQ is 2GB up to 3.7.0, which 128MB is also the new max size limit in 3.8.0 and onward.
you can't upload coco json file larger than 128M in newer version.